### PR TITLE
_httpdomain.py: import both collections and collections.abc

### DIFF
--- a/sphinxcontrib/openapi/renderers/_httpdomain.py
+++ b/sphinxcontrib/openapi/renderers/_httpdomain.py
@@ -1,10 +1,9 @@
 """OpenAPI spec renderer."""
 
 import sys
-if sys.version_info >= (3, 3):
-    import collections.abc as collections
-else:
-    import collections
+
+import collections
+import collections.abc
 
 import copy
 import functools
@@ -179,7 +178,7 @@ def _get_schema_type(schema):
 
 
 _merge_mappings = deepmerge.Merger(
-    [(collections.Mapping, deepmerge.strategy.dict.DictStrategies("merge"))],
+    [(collections.abc.Mapping, deepmerge.strategy.dict.DictStrategies("merge"))],
     ["override"],
     ["override"],
 ).merge


### PR DESCRIPTION
While a1d4fca2e7c3ae3cca69593baade1ebc297a12ff fixed the import for
collections.Mapping, using collections.defaultdict broke.

Import both packages, and use them where appropriate.